### PR TITLE
Treat SSG08 as preferred weapon

### DIFF
--- a/RetakesAllocatorCore/WeaponHelpers.cs
+++ b/RetakesAllocatorCore/WeaponHelpers.cs
@@ -72,8 +72,6 @@ public static class WeaponHelpers
         CsItem.XM1014,
         CsItem.Nova,
 
-        // Sniper
-        CsItem.Scout,
     };
 
     private static readonly ICollection<CsItem> _tMidRange = new HashSet<CsItem>
@@ -118,6 +116,7 @@ public static class WeaponHelpers
     private static readonly ICollection<CsItem> _sharedPreferred = new HashSet<CsItem>
     {
         CsItem.AWP,
+        CsItem.Scout,
     };
 
     private static readonly ICollection<CsItem> _tPreferred = new HashSet<CsItem>
@@ -412,14 +411,14 @@ public static class WeaponHelpers
             return null;
         }
 
-        if (item == CsItem.AWP)
+        return item switch
         {
-            return item;
-        }
-
-        // Right now these are the only other preferred guns
-        // If we make preferred guns configurable, we'll have to change this
-        return team == CsTeam.Terrorist ? CsItem.AutoSniperT : CsItem.AutoSniperCT;
+            CsItem.AWP => item,
+            CsItem.Scout => item,
+            CsItem.AutoSniperT => team == CsTeam.Terrorist ? CsItem.AutoSniperT : CsItem.AutoSniperCT,
+            CsItem.AutoSniperCT => team == CsTeam.Terrorist ? CsItem.AutoSniperT : CsItem.AutoSniperCT,
+            _ => null,
+        };
     }
 
     public static ICollection<RoundType> GetRoundTypesForWeapon(CsItem weapon)

--- a/RetakesAllocatorTest/WeaponSelectionTests.cs
+++ b/RetakesAllocatorTest/WeaponSelectionTests.cs
@@ -158,6 +158,37 @@ public class WeaponSelectionTests : BaseTestFixture
     }
 
     [Test]
+    public async Task PreferredScoutCanBeSetAndRemoved()
+    {
+        var args = new List<string> {"weapon_ssg08"};
+        var team = CsTeam.CounterTerrorist;
+
+        await OnWeaponCommandHelper.HandleAsync(args, TestSteamId, RoundType.FullBuy, team, false);
+
+        var userSettings = await Queries.GetUserSettings(TestSteamId);
+        Assert.That(
+            userSettings?.GetWeaponPreference(team, WeaponAllocationType.Preferred),
+            Is.EqualTo(CsItem.Scout));
+        Assert.That(
+            userSettings?.GetWeaponPreference(CsTeam.Terrorist, WeaponAllocationType.Preferred),
+            Is.EqualTo(CsItem.Scout));
+
+        var allocationType =
+            WeaponHelpers.GetWeaponAllocationTypeForWeaponAndRound(RoundType.FullBuy, team, CsItem.Scout);
+        Assert.That(allocationType, Is.EqualTo(WeaponAllocationType.Preferred));
+
+        await OnWeaponCommandHelper.HandleAsync(args, TestSteamId, RoundType.FullBuy, team, true);
+
+        userSettings = await Queries.GetUserSettings(TestSteamId);
+        Assert.That(
+            userSettings?.GetWeaponPreference(team, WeaponAllocationType.Preferred),
+            Is.EqualTo(null));
+        Assert.That(
+            userSettings?.GetWeaponPreference(CsTeam.Terrorist, WeaponAllocationType.Preferred),
+            Is.EqualTo(null));
+    }
+
+    [Test]
     [Retry(3)]
     public void RandomWeaponSelection()
     {


### PR DESCRIPTION
## Summary
- move the SSG08 into the shared preferred weapon pools so it is treated as a full-buy sniper
- update preferred weapon coercion to keep the SSG08 intact instead of forcing an autosniper
- add a regression test covering selection and removal of the preferred SSG08 during full-buy rounds

## Testing
- dotnet test *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68cdd0f9a30c83229babdded3b2dfa7f