### PR TITLE
Switch preferred sniper menu to SSG08

### DIFF
--- a/RetakesAllocator/Menus/AdvancedGunMenu.cs
+++ b/RetakesAllocator/Menus/AdvancedGunMenu.cs
@@ -74,10 +74,10 @@ public class AdvancedGunMenu
                 string BottomMenu = string.IsNullOrEmpty(Translator.Instance["menu.bottom.text"]) ? "" : Translator.Instance["menu.bottom.text"];
                 string BottomMenuOnpistol = string.IsNullOrEmpty(Translator.Instance["menu.bottom.text.pistol"]) ? "" : Translator.Instance["menu.bottom.text.pistol"];
 
-                string[] Main = { 
-                    string.IsNullOrEmpty(Translator.Instance["menu.main.tloadout"]) ? "█░ T Loadout ░█" : Translator.Instance["menu.main.tloadout"], 
-                    string.IsNullOrEmpty(Translator.Instance["menu.main.ctloadout"]) ? "█░ CT Loadout ░█" : Translator.Instance["menu.main.ctloadout"], 
-                    string.IsNullOrEmpty(Translator.Instance["menu.main.awp"]) ? "█░ AWP ░█" : Translator.Instance["menu.main.awp"]
+                string[] Main = {
+                    string.IsNullOrEmpty(Translator.Instance["menu.main.tloadout"]) ? "█░ T Loadout ░█" : Translator.Instance["menu.main.tloadout"],
+                    string.IsNullOrEmpty(Translator.Instance["menu.main.ctloadout"]) ? "█░ CT Loadout ░█" : Translator.Instance["menu.main.ctloadout"],
+                    string.IsNullOrEmpty(Translator.Instance["menu.main.awp"]) ? "█░ SSG08 ░█" : Translator.Instance["menu.main.awp"]
                 };
 
                 List<string> TFullBuyList = new List<string>();
@@ -104,8 +104,8 @@ public class AdvancedGunMenu
                     string.IsNullOrEmpty(Translator.Instance["menu.ctHalfbuy"]) ? "█ CT Half Buy █" : Translator.Instance["menu.ctHalfbuy"]
                 };
 
-                string[] AWP = { 
-                    string.IsNullOrEmpty(Translator.Instance["menu.awp.always"]) ? "Always" : Translator.Instance["menu.awp.always"], 
+                string[] PreferredSniperOptions = {
+                    string.IsNullOrEmpty(Translator.Instance["menu.awp.always"]) ? "Always" : Translator.Instance["menu.awp.always"],
                     string.IsNullOrEmpty(Translator.Instance["menu.awp.never"]) ? "Never" : Translator.Instance["menu.awp.never"]
                 };
 
@@ -203,9 +203,9 @@ public class AdvancedGunMenu
                         currentIndexDict[playerid] = (currentIndexDict[playerid] == CTPistolRound.Length - 1) ? 0 : currentIndexDict[playerid] + 1;
                     }
 
-                    if (mainmenu[playerid] == 9)//AWP loadout
+                    if (mainmenu[playerid] == 9)//Preferred sniper loadout
                     {
-                        currentIndexDict[playerid] = (currentIndexDict[playerid] == AWP.Length - 1) ? 0 : currentIndexDict[playerid] + 1;
+                        currentIndexDict[playerid] = (currentIndexDict[playerid] == PreferredSniperOptions.Length - 1) ? 0 : currentIndexDict[playerid] + 1;
                     }
                     if (mainmenu[playerid] == 11)//CT Half Buy
                     {
@@ -260,9 +260,9 @@ public class AdvancedGunMenu
                         currentIndexDict[playerid] = (currentIndexDict[playerid] == 0) ? CTPistolRound.Length - 1 : currentIndexDict[playerid] - 1;
                     }
 
-                    if (mainmenu[playerid] == 9)//AWP loadout
+                    if (mainmenu[playerid] == 9)//Preferred sniper loadout
                     {
-                        currentIndexDict[playerid] = (currentIndexDict[playerid] == 0) ? AWP.Length - 1 : currentIndexDict[playerid] - 1;
+                        currentIndexDict[playerid] = (currentIndexDict[playerid] == 0) ? PreferredSniperOptions.Length - 1 : currentIndexDict[playerid] - 1;
                     }
                     if (mainmenu[playerid] == 11)//CT Half Buy
                     {
@@ -327,15 +327,15 @@ public class AdvancedGunMenu
 
                     if (mainmenu[playerid] == 9)
                     {
-                        string currentLineName = AWP[currentLineIndex];
-                        if (currentLineName == AWP[0])
+                        string currentLineName = PreferredSniperOptions[currentLineIndex];
+                        if (currentLineName == PreferredSniperOptions[0])
                         {
-                            GunsMenu.HandlePreferenceSelection(player, CsTeam.Terrorist, CsItem.AWP.ToString(), remove: false);
+                            GunsMenu.HandlePreferenceSelection(player, CsTeam.Terrorist, CsItem.Scout.ToString(), remove: false);
                             Print(player, Translator.Instance["guns_menu.awp_preference_selected",currentLineName]);
                         }
-                        if (currentLineName == AWP[1])
+                        if (currentLineName == PreferredSniperOptions[1])
                         {
-                            GunsMenu.HandlePreferenceSelection(player, CsTeam.Terrorist, CsItem.AWP.ToString(), remove: true);
+                            GunsMenu.HandlePreferenceSelection(player, CsTeam.Terrorist, CsItem.Scout.ToString(), remove: true);
                             Print(player, Translator.Instance["guns_menu.awp_preference_selected",currentLineName]);
                         }
                     }
@@ -551,16 +551,16 @@ public class AdvancedGunMenu
                     }
                     if(mainmenu[playerid] == 9)
                     {
-                        for (int i = 0; i < AWP.Length; i++)
+                        for (int i = 0; i < PreferredSniperOptions.Length; i++)
                         {
-                            if (i == currentIndexDict[playerid]) 
+                            if (i == currentIndexDict[playerid])
                             {
-                                string lineHtml = $"<font color='orange'>{Imageleft} {AWP[i]} {ImageRight}</font><br>";
+                                string lineHtml = $"<font color='orange'>{Imageleft} {PreferredSniperOptions[i]} {ImageRight}</font><br>";
                                 builder.AppendLine(lineHtml);
                             }
                             else
                             {
-                                builder.AppendLine($"<font color='white'>{AWP[i]}</font><br>");
+                                builder.AppendLine($"<font color='white'>{PreferredSniperOptions[i]}</font><br>");
                             }
                         }
                         builder.AppendLine(BottomMenu);

--- a/RetakesAllocator/Menus/GunsMenu.cs
+++ b/RetakesAllocator/Menus/GunsMenu.cs
@@ -373,20 +373,20 @@ public class GunsMenu : AbstractBaseMenu
         ]);
         HandlePreferenceSelection(player, CsTeam.CounterTerrorist, weaponName);
 
-        OpenGiveAwpMenu(player);
+        OpenGiveScoutMenu(player);
     }
 
-    private string AwpNeverOption => Translator.Instance["guns_menu.awp_never"];
-    private string AwpMyTurnOption => Translator.Instance["guns_menu.awp_always"];
+    private string ScoutNeverOption => Translator.Instance["guns_menu.awp_never"];
+    private string ScoutMyTurnOption => Translator.Instance["guns_menu.awp_always"];
 
-    private void OpenGiveAwpMenu(CCSPlayerController player)
+    private void OpenGiveScoutMenu(CCSPlayerController player)
     {
         var menu = new ChatMenu($"{MessagePrefix}{Translator.Instance["guns_menu.awp_menu"]}");
 
-        menu.AddMenuOption(AwpNeverOption, OnGiveAwpSelect);
-        // Implementing "Sometimes" will require a more complex AWP queue
-        // menu.AddMenuOption("Sometimes", OnGiveAwpSelect);
-        menu.AddMenuOption(AwpMyTurnOption, OnGiveAwpSelect);
+        menu.AddMenuOption(ScoutNeverOption, OnGiveScoutSelect);
+        // Implementing "Sometimes" will require a more complex SSG08 queue
+        // menu.AddMenuOption("Sometimes", OnGiveScoutSelect);
+        menu.AddMenuOption(ScoutMyTurnOption, OnGiveScoutSelect);
 
         menu.AddMenuOption(Translator.Instance["menu.exit"], OnSelectExit);
 
@@ -394,7 +394,7 @@ public class GunsMenu : AbstractBaseMenu
         CreateMenuTimeoutTimer(player);
     }
 
-    private void OnGiveAwpSelect(CCSPlayerController player, ChatMenuOption option)
+    private void OnGiveScoutSelect(CCSPlayerController player, ChatMenuOption option)
     {
         if (!PlayersInMenu.Contains(player))
         {
@@ -406,14 +406,14 @@ public class GunsMenu : AbstractBaseMenu
             Translator.Instance["guns_menu.awp_preference_selected", option.Text]
         );
 
-        if (option.Text == AwpNeverOption)
+        if (option.Text == ScoutNeverOption)
         {
-            // Team doesnt matter for AWP
-            HandlePreferenceSelection(player, CsTeam.Terrorist, CsItem.AWP.ToString(), remove: true);
+            // Team doesnt matter for preferred sniper
+            HandlePreferenceSelection(player, CsTeam.Terrorist, CsItem.Scout.ToString(), remove: true);
         }
-        else if (option.Text == AwpMyTurnOption)
+        else if (option.Text == ScoutMyTurnOption)
         {
-            HandlePreferenceSelection(player, CsTeam.Terrorist, CsItem.AWP.ToString(), remove: false);
+            HandlePreferenceSelection(player, CsTeam.Terrorist, CsItem.Scout.ToString(), remove: false);
         }
 
         OnMenuComplete(player);

--- a/RetakesAllocator/lang/en.json
+++ b/RetakesAllocator/lang/en.json
@@ -41,14 +41,14 @@
   "guns_menu.complete": "You have finished setting up your weapons!\nThe weapons you have selected will be given to you at the start of the next round!",
   "guns_menu.select_weapon": "Select a {0} {1} Weapon",
   "guns_menu.weapon_selected": "You selected {0} as {1} {2} weapon!",
-  "guns_menu.awp_menu": "Select when to give the AWP",
+  "guns_menu.awp_menu": "Select when to give the SSG08",
   "guns_menu.awp_always": "Always",
   "guns_menu.awp_never": "Never",
-  "guns_menu.awp_preference_selected": "You selected '{0}' as when to give the AWP!",
+  "guns_menu.awp_preference_selected": "You selected '{0}' as when to give the SSG08!",
 
   "menu.main.tloadout": "█░ T Loadout ░█",
   "menu.main.ctloadout": "█░ CT Loadout ░█",
-  "menu.main.awp": "█░ AWP ░█",
+  "menu.main.awp": "█░ SSG08 ░█",
 
   "menu.tprimary": "█ T Primary █",
   "menu.tsecondary": "█ T Secondary █",

--- a/RetakesAllocator/lang/pt-BR.json
+++ b/RetakesAllocator/lang/pt-BR.json
@@ -41,14 +41,14 @@
   "guns_menu.complete": "Você terminou de configurar suas armas!\nAs armas que você selecionou serão entregues a você no início da próximo round!",
   "guns_menu.select_weapon": "Selecione uma arma {0} {1}",
   "guns_menu.weapon_selected": "Você selecionou {0} como arma {1} {2}!",
-  "guns_menu.awp_menu": "Selecione quando receber a AWP",
+  "guns_menu.awp_menu": "Selecione quando receber a SSG08",
   "guns_menu.awp_always": "Sempre",
   "guns_menu.awp_never": "Nunca",
-  "guns_menu.awp_preference_selected": "Você selecionou '{0}' para receber a AWP!",
+  "guns_menu.awp_preference_selected": "Você selecionou '{0}' para receber a SSG08!",
 
   "menu.main.tloadout": "█ Loadout T █",
   "menu.main.ctloadout": "█ Loadout CT █",
-  "menu.main.awp": "█ AWP █",
+  "menu.main.awp": "█ SSG08 █",
 
   "menu.tprimary": "█ Primária T █",
   "menu.tsecondary": "█ Secundária T █",

--- a/RetakesAllocator/lang/pt-PT.json
+++ b/RetakesAllocator/lang/pt-PT.json
@@ -41,14 +41,14 @@
   "guns_menu.complete": "Terminaste de configurar as tuas armas!\nAs armas que selecionaste ser-te-ão entregues no início da próxima ronda!",
   "guns_menu.select_weapon": "Seleciona uma arma {0} {1}",
   "guns_menu.weapon_selected": "Selecionaste {0} como arma {1} {2}!",
-  "guns_menu.awp_menu": "Seleciona quando receber a AWP",
+  "guns_menu.awp_menu": "Seleciona quando receber a SSG08",
   "guns_menu.awp_always": "Sempre",
   "guns_menu.awp_never": "Nunca",
-  "guns_menu.awp_preference_selected": "Selecionaste '{0}' para receber a AWP!",
+  "guns_menu.awp_preference_selected": "Selecionaste '{0}' para receber a SSG08!",
 
   "menu.main.tloadout": "█ Loadout T █",
   "menu.main.ctloadout": "█ Loadout CT █",
-  "menu.main.awp": "█ AWP █",
+  "menu.main.awp": "█ SSG08 █",
 
   "menu.tprimary": "█ Primária T █",
   "menu.tsecondary": "█ Secundária T █",

--- a/RetakesAllocator/lang/zh-Hans.json
+++ b/RetakesAllocator/lang/zh-Hans.json
@@ -40,14 +40,14 @@
   "guns_menu.complete": "您已经完成了武器设置！\n您选择的武器将在下一轮开始时给予您！",
   "guns_menu.select_weapon": "选择一个 {0} {1} 武器",
   "guns_menu.weapon_selected": "您选择了 {0} 作为 {1} {2} 武器！",
-  "guns_menu.awp_menu": "选择何时给予 AWP",
+  "guns_menu.awp_menu": "选择何时给予 SSG08",
   "guns_menu.awp_always": "始终",
   "guns_menu.awp_never": "从不",
-  "guns_menu.awp_preference_selected": "您选择了 '{0}' 作为何时给予 AWP！",
+  "guns_menu.awp_preference_selected": "您选择了 '{0}' 作为何时给予 SSG08！",
 
   "menu.main.tloadout": "█░ T 装备 ░█",
   "menu.main.ctloadout": "█░ CT 装备 ░█",
-  "menu.main.awp": "█░ AWP ░█",
+  "menu.main.awp": "█░ SSG08 ░█",
 
   "menu.tprimary": "█ T 主武器 █",
   "menu.tsecondary": "█ T 手枪 █",

--- a/RetakesAllocatorCore/OnWeaponCommandHelper.cs
+++ b/RetakesAllocatorCore/OnWeaponCommandHelper.cs
@@ -74,16 +74,17 @@ public class OnWeaponCommandHelper
         }
 
         var weapon = foundWeapons.First();
+        var weaponName = weapon.GetName();
 
         if (!WeaponHelpers.IsUsableWeapon(weapon))
         {
-            return Ret(Translator.Instance["weapon_preference.not_allowed", weapon]);
+            return Ret(Translator.Instance["weapon_preference.not_allowed", weaponName]);
         }
 
         var weaponRoundTypes = WeaponHelpers.GetRoundTypesForWeapon(weapon);
         if (weaponRoundTypes.Count == 0)
         {
-            return Ret(Translator.Instance["weapon_preference.invalid_weapon", weapon]);
+            return Ret(Translator.Instance["weapon_preference.invalid_weapon", weaponName]);
         }
 
         var allocationType = WeaponHelpers.GetWeaponAllocationTypeForWeaponAndRound(
@@ -105,7 +106,7 @@ public class OnWeaponCommandHelper
 
         if (allocationType is null)
         {
-            return Ret(Translator.Instance["weapon_preference.not_valid_for_team", weapon, team]);
+            return Ret(Translator.Instance["weapon_preference.not_valid_for_team", weaponName, team]);
         }
 
 
@@ -114,13 +115,13 @@ public class OnWeaponCommandHelper
             if (isPreferred)
             {
                 _ = Queries.SetPreferredWeaponPreferenceAsync(userId, null);
-                return Ret(Translator.Instance["weapon_preference.unset_preference_preferred", weapon]);
+                return Ret(Translator.Instance["weapon_preference.unset_preference_preferred", weaponName]);
             }
             else
             {
                 _ = Queries.SetWeaponPreferenceForUserAsync(userId, team, allocationType.Value, null);
                 return Ret(
-                    Translator.Instance["weapon_preference.unset_preference", weapon, allocationType.Value, team]);
+                    Translator.Instance["weapon_preference.unset_preference", weaponName, allocationType.Value, team]);
             }
         }
 
@@ -129,12 +130,12 @@ public class OnWeaponCommandHelper
         {
             _ = Queries.SetPreferredWeaponPreferenceAsync(userId, weapon);
             // If we ever add more preferred weapons, we need to change the wording of "sniper" here
-            message = Translator.Instance["weapon_preference.set_preference_preferred", weapon];
+            message = Translator.Instance["weapon_preference.set_preference_preferred", weaponName];
         }
         else
         {
             _ = Queries.SetWeaponPreferenceForUserAsync(userId, team, allocationType.Value, weapon);
-            message = Translator.Instance["weapon_preference.set_preference", weapon, allocationType.Value, team];
+            message = Translator.Instance["weapon_preference.set_preference", weaponName, allocationType.Value, team];
         }
 
         if (allocateImmediately)

--- a/RetakesAllocatorCore/WeaponHelpers.cs
+++ b/RetakesAllocatorCore/WeaponHelpers.cs
@@ -250,11 +250,16 @@ public static class WeaponHelpers
     {
         {"m4a1", CsItem.M4A1S},
         {"m4a1-s", CsItem.M4A1S},
+        {"awp", CsItem.Scout},
+        {"weapon_awp", CsItem.AWP},
+        {"ssg08", CsItem.Scout},
+        {"weapon_ssg08", CsItem.Scout},
     };
 
     private static readonly Dictionary<CsItem, string> _weaponNameOverrides = new()
     {
         {CsItem.M4A4, "M4A4"},
+        {CsItem.Scout, "SSG08"},
     };
 
     public static List<WeaponAllocationType> WeaponAllocationTypes =>

--- a/RetakesAllocatorTest/WeaponSelectionTests.cs
+++ b/RetakesAllocatorTest/WeaponSelectionTests.cs
@@ -79,8 +79,8 @@ public class WeaponSelectionTests : BaseTestFixture
     [TestCase(null, CsTeam.Terrorist, "ak", null, "AK47' is now", "AK47' is no longer")]
     [TestCase(RoundType.FullBuy, CsTeam.Spectator, "ak", null, "must join a team", "must join a team")]
     [TestCase(RoundType.FullBuy, CsTeam.Terrorist, "ak,F", null, "Invalid team", "Invalid team")]
-    [TestCase(RoundType.FullBuy, CsTeam.Terrorist, "awp", null, "will now get a 'AWP", "no longer receive 'AWP")]
-    [TestCase(RoundType.Pistol, CsTeam.CounterTerrorist, "awp", null, "will now get a 'AWP", "no longer receive 'AWP")]
+    [TestCase(RoundType.FullBuy, CsTeam.Terrorist, "awp", null, "will now get a 'SSG08", "no longer receive 'SSG08")]
+    [TestCase(RoundType.Pistol, CsTeam.CounterTerrorist, "awp", null, "will now get a 'SSG08", "no longer receive 'SSG08")]
     public async Task SetWeaponPreferenceCommandSingleArg(
         RoundType? roundType,
         CsTeam team,


### PR DESCRIPTION
## Summary
- replace the AWP preference menus with SSG08 options in both the standard and advanced gun menus
- update localization strings so the UI now references the SSG08 sniper across supported languages
- adjust weapon preference handling and tests so preferred sniper messages use the SSG08 label

## Testing
- dotnet test *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cdd21ccc348322a7d112ffa71ccda4