### PR TITLE
Map scout aliases to item

### DIFF
--- a/RetakesAllocatorCore/WeaponHelpers.cs
+++ b/RetakesAllocatorCore/WeaponHelpers.cs
@@ -250,6 +250,8 @@ public static class WeaponHelpers
     {
         {"m4a1", CsItem.M4A1S},
         {"m4a1-s", CsItem.M4A1S},
+        {"weapon_ssg08", CsItem.Scout},
+        {"ssg08", CsItem.Scout},
     };
 
     private static readonly Dictionary<CsItem, string> _weaponNameOverrides = new()

--- a/RetakesAllocatorTest/WeaponHelpersTests.cs
+++ b/RetakesAllocatorTest/WeaponHelpersTests.cs
@@ -1,3 +1,4 @@
+using CounterStrikeSharp.API.Modules.Entities.Constants;
 using RetakesAllocatorCore;
 using RetakesAllocatorCore.Config;
 
@@ -17,5 +18,15 @@ public class WeaponHelpersTests : BaseTestFixture
         var canAllocate = WeaponHelpers.IsWeaponAllocationAllowed(isFreezeTime);
 
         Assert.That(canAllocate, Is.EqualTo(expected));
+    }
+
+    [Test]
+    [TestCase("weapon_ssg08")]
+    [TestCase("ssg08")]
+    public void FindValidWeaponsByName_FindsScoutAliases(string alias)
+    {
+        var results = WeaponHelpers.FindValidWeaponsByName(alias);
+
+        Assert.That(results, Is.EquivalentTo(new[] {CsItem.Scout}));
     }
 }


### PR DESCRIPTION
## Summary
- map weapon_ssg08 and ssg08 search overrides to CsItem.Scout so scout aliases resolve directly
- cover the lookup with a unit test to ensure the aliases return the scout

## Testing
- dotnet test

------
https://chatgpt.com/codex/tasks/task_e_68cdd74fda0883229e8a06d9c63438ee