### PR TITLE
Rename preferred weapon configuration to AWP

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,11 +170,11 @@ Here are the weapon configs:
 
 
 - `ZeusPreference`: Whether or not to give a Zeus. Options are `Always` or `Never`. Defaults to `Never`.
-- `AllowPreferredWeaponForEveryone`: If `true`, everyone can get the AWP. This overrides every other "preferred" weapon
+- `AllowAwpWeaponForEveryone`: If `true`, everyone can get the AWP. This overrides every other "preferred" weapon
   setting. Defaults to `false`.
-- `MaxPreferredWeaponsPerTeam`: The maximum number of AWPs for each team.
-- `MinPlayersPerTeamForPreferredWeapon`: The minimum number of players on each team necessary for someone to get an AWP.
-- `ChanceForPreferredWeapon`: The % chance that the round will have an AWP.
+- `MaxAwpWeaponsPerTeam`: The maximum number of AWPs for each team.
+- `MinPlayersPerTeamForAwpWeapon`: The minimum number of players on each team necessary for someone to get an AWP.
+- `ChanceForAwpWeapon`: The % chance that the round will have an AWP.
 
 #### Nade Configuration
 
@@ -267,7 +267,7 @@ room for it*.
 #### Other Configuration
 
 - `EnableNextRoundTypeVoting`: Whether to allow voting for the next round type via `!nextround`. `false` by default.
-- `NumberOfExtraVipChancesForPreferredWeapon`: When randomly selecting preferred weapons per team (ie. "AWP queue"), how
+- `NumberOfExtraVipChancesForAwpWeapon`: When randomly selecting AWPs per team (ie. "AWP queue"), how
   many extra chances should VIPs get.
     - The default is 1, meaning VIPs will get 1 extra chance. For example, lets say
       there are 3 players on the team and this config is set to 1. Normally each person would have a 33% chance of
@@ -277,7 +277,7 @@ room for it*.
       the other two players will each have 25% chance of getting the AWP.
     - If you set this to 0, there will be no preference for VIPs.
     - If you set this to -1, only VIPs can get the AWP
-- `ChanceForPreferredWeapon`: This allows you to determine chance of players getting preferred weapon. (ie. 100 = %100, 50 = %50)
+- `ChanceForAwpWeapon`: This allows you to determine chance of players getting the AWP. (ie. 100 = %100, 50 = %50)
 - `AllowedWeaponSelectionTypes`: The types of weapon allocation that are allowed.
     - Choices:
         - `PlayerChoice` - Allow players to choose their preferences for the round type

--- a/RetakesAllocator/RetakesAllocator.cs
+++ b/RetakesAllocator/RetakesAllocator.cs
@@ -267,7 +267,7 @@ public class RetakesAllocator : BasePlugin
 
         var currentTeam = player!.Team;
 
-        if (Configs.GetConfigData().NumberOfExtraVipChancesForPreferredWeapon == -1 && !Helpers.IsVip(player))
+        if (Configs.GetConfigData().NumberOfExtraVipChancesForAwpWeapon == -1 && !Helpers.IsVip(player))
         {
             var message = Translator.Instance["weapon_preference.only_vip_can_use"];
             commandInfo.ReplyToCommand($"{MessagePrefix}{message}");

--- a/RetakesAllocatorCore/Config/Configs.cs
+++ b/RetakesAllocatorCore/Config/Configs.cs
@@ -244,18 +244,18 @@ public record ConfigData
     public float BombSiteAnnouncementCenterShowTimer { get; set; } = 5.0f;
     public bool EnableBombSiteAnnouncementChat { get; set; } = false;
     public bool EnableNextRoundTypeVoting { get; set; } = false;
-    public int NumberOfExtraVipChancesForPreferredWeapon { get; set; } = 1;
-    public bool AllowPreferredWeaponForEveryone { get; set; } = false;
+    public int NumberOfExtraVipChancesForAwpWeapon { get; set; } = 1;
+    public bool AllowAwpWeaponForEveryone { get; set; } = false;
 
-    public double ChanceForPreferredWeapon { get; set; } = 100;
+    public double ChanceForAwpWeapon { get; set; } = 100;
 
-    public Dictionary<CsTeam, int> MaxPreferredWeaponsPerTeam { get; set; } = new()
+    public Dictionary<CsTeam, int> MaxAwpWeaponsPerTeam { get; set; } = new()
     {
         {CsTeam.Terrorist, 1},
         {CsTeam.CounterTerrorist, 1},
     };
 
-    public Dictionary<CsTeam, int> MinPlayersPerTeamForPreferredWeapon { get; set; } = new()
+    public Dictionary<CsTeam, int> MinPlayersPerTeamForAwpWeapon { get; set; } = new()
     {
         {CsTeam.Terrorist, 1},
         {CsTeam.CounterTerrorist, 1},

--- a/RetakesAllocatorCore/Db/Queries.cs
+++ b/RetakesAllocatorCore/Db/Queries.cs
@@ -65,7 +65,7 @@ public class Queries
         Task.Run(async () => { await ClearWeaponPreferencesForUserAsync(userId); });
     }
 
-    public static async Task SetPreferredWeaponPreferenceAsync(ulong userId, CsItem? item)
+    public static async Task SetAwpWeaponPreferenceAsync(ulong userId, CsItem? item)
     {
         await UpsertUserSettings(userId, userSetting =>
         {
@@ -76,9 +76,9 @@ public class Queries
         });
     }
 
-    public static void SetPreferredWeaponPreference(ulong userId, CsItem? item)
+    public static void SetAwpWeaponPreference(ulong userId, CsItem? item)
     {
-        Task.Run(async () => { await SetPreferredWeaponPreferenceAsync(userId, item); });
+        Task.Run(async () => { await SetAwpWeaponPreferenceAsync(userId, item); });
     }
 
     public static IDictionary<ulong, UserSetting> GetUsersSettings(ICollection<ulong> userIds)

--- a/RetakesAllocatorCore/OnRoundPostStartHelper.cs
+++ b/RetakesAllocatorCore/OnRoundPostStartHelper.cs
@@ -51,7 +51,7 @@ public class OnRoundPostStartHelper
 
         var defusingPlayer = Utils.Choice(ctPlayers);
 
-        HashSet<T> FilterByPreferredWeaponPreference(IEnumerable<T> ps) =>
+        HashSet<T> FilterByAwpWeaponPreference(IEnumerable<T> ps) =>
             ps.Where(p =>
                     userSettingsByPlayerId.TryGetValue(getSteamId(p), out var userSetting) &&
                     userSetting.GetWeaponPreference(getTeam(p), WeaponAllocationType.Preferred) is not null)
@@ -63,13 +63,13 @@ public class OnRoundPostStartHelper
         Random random = new Random();
         double generatedChance = random.NextDouble() * 100;
 
-        if (roundType == RoundType.FullBuy && generatedChance <= Configs.GetConfigData().ChanceForPreferredWeapon)
+        if (roundType == RoundType.FullBuy && generatedChance <= Configs.GetConfigData().ChanceForAwpWeapon)
         {
             tPreferredPlayers =
-                WeaponHelpers.SelectPreferredPlayers(FilterByPreferredWeaponPreference(tPlayers), isVip,
+                WeaponHelpers.SelectPreferredPlayers(FilterByAwpWeaponPreference(tPlayers), isVip,
                     CsTeam.Terrorist);
             ctPreferredPlayers =
-                WeaponHelpers.SelectPreferredPlayers(FilterByPreferredWeaponPreference(ctPlayers), isVip,
+                WeaponHelpers.SelectPreferredPlayers(FilterByAwpWeaponPreference(ctPlayers), isVip,
                     CsTeam.CounterTerrorist);
         }
 

--- a/RetakesAllocatorCore/OnWeaponCommandHelper.cs
+++ b/RetakesAllocatorCore/OnWeaponCommandHelper.cs
@@ -113,7 +113,7 @@ public class OnWeaponCommandHelper
         {
             if (isPreferred)
             {
-                _ = Queries.SetPreferredWeaponPreferenceAsync(userId, null);
+                _ = Queries.SetAwpWeaponPreferenceAsync(userId, null);
                 return Ret(Translator.Instance["weapon_preference.unset_preference_preferred", weapon]);
             }
             else
@@ -127,7 +127,7 @@ public class OnWeaponCommandHelper
         string message;
         if (isPreferred)
         {
-            _ = Queries.SetPreferredWeaponPreferenceAsync(userId, weapon);
+            _ = Queries.SetAwpWeaponPreferenceAsync(userId, weapon);
             // If we ever add more preferred weapons, we need to change the wording of "sniper" here
             message = Translator.Instance["weapon_preference.set_preference_preferred", weapon];
         }

--- a/RetakesAllocatorCore/WeaponHelpers.cs
+++ b/RetakesAllocatorCore/WeaponHelpers.cs
@@ -342,14 +342,14 @@ public static class WeaponHelpers
 
     public static IList<T> SelectPreferredPlayers<T>(IEnumerable<T> players, Func<T, bool> isVip, CsTeam team)
     {
-        if (Configs.GetConfigData().AllowPreferredWeaponForEveryone)
+        if (Configs.GetConfigData().AllowAwpWeaponForEveryone)
         {
             return new List<T>(players);
         }
 
         var playersList = players.ToList();
 
-        if (Configs.GetConfigData().MinPlayersPerTeamForPreferredWeapon.TryGetValue(team, out var minTeamPlayers))
+        if (Configs.GetConfigData().MinPlayersPerTeamForAwpWeapon.TryGetValue(team, out var minTeamPlayers))
         {
             if (playersList.Count < minTeamPlayers)
             {
@@ -357,7 +357,7 @@ public static class WeaponHelpers
             }
         }
 
-        if (!Configs.GetConfigData().MaxPreferredWeaponsPerTeam.TryGetValue(team, out var maxPerTeam))
+        if (!Configs.GetConfigData().MaxAwpWeaponsPerTeam.TryGetValue(team, out var maxPerTeam))
         {
             maxPerTeam = 1;
         }
@@ -370,7 +370,7 @@ public static class WeaponHelpers
         var choicePlayers = new List<T>();
         foreach (var p in playersList)
         {
-            if (Configs.GetConfigData().NumberOfExtraVipChancesForPreferredWeapon == -1)
+            if (Configs.GetConfigData().NumberOfExtraVipChancesForAwpWeapon == -1)
             {
                 if (isVip(p))
                 {
@@ -382,7 +382,7 @@ public static class WeaponHelpers
                 choicePlayers.Add(p);
                 if (isVip(p))
                 {
-                    for (var i = 0; i < Configs.GetConfigData().NumberOfExtraVipChancesForPreferredWeapon; i++)
+                    for (var i = 0; i < Configs.GetConfigData().NumberOfExtraVipChancesForAwpWeapon; i++)
                     {
                         choicePlayers.Add(p);
                     }
@@ -558,8 +558,19 @@ public static class WeaponHelpers
             return new List<CsItem> {nameOverride};
         }
 
+        var needles = new HashSet<string> {needle};
+        const string weaponPrefix = "weapon_";
+        if (needle.StartsWith(weaponPrefix))
+        {
+            needles.Add(needle[weaponPrefix.Length..]);
+        }
+
         return Enum.GetNames<CsItem>()
-            .Where(name => name.ToLower().Contains(needle))
+            .Where(name =>
+            {
+                var lowered = name.ToLower();
+                return needles.Any(n => lowered.Contains(n));
+            })
             .Select(Enum.Parse<CsItem>)
             .ToList();
     }

--- a/RetakesAllocatorTest/DbTests.cs
+++ b/RetakesAllocatorTest/DbTests.cs
@@ -22,14 +22,14 @@ public class DbTests : BaseTestFixture
         await Queries.SetWeaponPreferenceForUserAsync(TestSteamId, CsTeam.CounterTerrorist, WeaponAllocationType.FullBuyPrimary,
             CsItem.AK47);
         // Should set for both T and CT
-        await Queries.SetPreferredWeaponPreferenceAsync(TestSteamId, CsItem.AWP);
+        await Queries.SetAwpWeaponPreferenceAsync(TestSteamId, CsItem.AWP);
 
         await Queries.SetWeaponPreferenceForUserAsync(2, CsTeam.Terrorist, WeaponAllocationType.FullBuyPrimary, CsItem.AK47);
         await Queries.SetWeaponPreferenceForUserAsync(2, CsTeam.Terrorist, WeaponAllocationType.Secondary, CsItem.Deagle);
         await Queries.SetWeaponPreferenceForUserAsync(2, CsTeam.CounterTerrorist, WeaponAllocationType.Secondary,
             CsItem.FiveSeven);
         // Will get different snipers for different teams
-        await Queries.SetPreferredWeaponPreferenceAsync(2, CsItem.SCAR20);
+        await Queries.SetAwpWeaponPreferenceAsync(2, CsItem.SCAR20);
 
         usersSettings = Queries.GetUsersSettings(new List<ulong> {TestSteamId});
         Assert.Multiple(() =>


### PR DESCRIPTION
## Summary
- rename config properties and references from PreferredWeapon to AwpWeapon and update documentation
- rename database helpers to SetAwpWeaponPreference and update call sites and tests
- adjust weapon lookup to handle the `weapon_` prefix and keep Scout preference commands working

## Testing
- dotnet build
- dotnet test

------
https://chatgpt.com/codex/tasks/task_e_68cddd3aec548322b027d4355711de95