### PR TITLE
Fix: CT nade allocation incorrectly uses T player count

### DIFF
--- a/RetakesAllocatorCore/OnRoundPostStartHelper.cs
+++ b/RetakesAllocatorCore/OnRoundPostStartHelper.cs
@@ -187,7 +187,7 @@ public class OnRoundPostStartHelper
                 RoundTypeManager.Instance.Map,
                 roundType,
                 CsTeam.CounterTerrorist,
-                tPlayers.Count
+                ctPlayers.Count
             ),
             ctPlayers,
             nadesByPlayer


### PR DESCRIPTION
## Summary

- `NadeHelpers.GetUtilForTeam()` for `CsTeam.CounterTerrorist` was called with `tPlayers.Count` instead of `ctPlayers.Count`
- This means CT nade totals were calculated based on T player count, not CT player count
- When using `Average*PerPlayer` settings (e.g. `AverageOnePerPlayer`), the formula `Math.Ceiling(numPlayers * multiplier)` would produce incorrect results for CT whenever team sizes differ

## Evidence this is a bug

The `MaxTeamNades` config supports **separate settings per team**:

```json
"MaxTeamNades": {
  "GLOBAL": {
    "Terrorist": {
      "FullBuy": "AverageOnePerPlayer"
    },
    "CounterTerrorist": {
      "FullBuy": "AverageOnePerPlayer"
    }
  }
}
```

If both teams were always intended to use T player count, there would be no reason to split this config by team. The per-team config structure confirms each team's nade pool should be based on its own player count.

## Fix

One-line change: `tPlayers.Count` → `ctPlayers.Count` for the CT `GetUtilForTeam` call in `OnRoundPostStartHelper.cs`.

## Test plan

- [x] `dotnet build -c Release` passes
- [x] `dotnet test RetakesAllocatorTest` — all 56 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)